### PR TITLE
Modifications for Ubuntu 24.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ install-manpages: $(MANPAGES)
 
 install: install-mnexec install-manpages
 #	This seems to work on all pip versions
-	$(PYTHON) -m pip uninstall -y mininet || true
-	$(PYTHON) -m pip install .
+	$(PYTHON) -m pip uninstall --break-system-packages -y mininet || true
+	$(PYTHON) -m pip install --break-system-packages .
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ install-manpages: $(MANPAGES)
 
 install: install-mnexec install-manpages
 #	This seems to work on all pip versions
-	$(PYTHON) -m pip uninstall --break-system-packages -y mininet || true
-	$(PYTHON) -m pip install --break-system-packages .
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip uninstall -y mininet || true
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install .
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/util/install.sh
+++ b/util/install.sh
@@ -175,6 +175,13 @@ function mn_deps {
     else  # Debian/Ubuntu
         pf=pyflakes
         pep8=pep8
+        apt_others=""
+        pip_yes="1"
+        if [ "$DIST" = "Ubuntu" -a `expr $RELEASE '>=' 24.04` = "1" ]; then
+                pep8="${PYPKG}-pep8"
+                apt_others="${PYPKG}-pexpect"
+                pip_yes="0"
+        fi
         # Starting around 20.04, installing pyflakes instead of pyflakes3
         # causes Python 2 to be installed, which is exactly NOT what we want.
         if [ "$DIST" = "Ubuntu" -a `expr $RELEASE '>=' 20.04` = "1" ]; then
@@ -190,7 +197,7 @@ function mn_deps {
 
         $install gcc make socat psmisc xterm ssh iperf telnet \
                  ethtool help2man $pf pylint $pep8 \
-                 net-tools ${PYPKG}-tk
+                 net-tools ${PYPKG}-tk ${apt_others}
 
         # Install pip
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
@@ -203,7 +210,9 @@ function mn_deps {
             sudo ${PYTHON} get-pip.py
             rm get-pip.py
         fi
-       ${python} -m pip install pexpect
+        if [ "$pip_yes" = "1" ]; then
+            ${python} -m pip install pexpect
+        fi
         $install iproute2 || $install iproute
         $install cgroup-tools || $install cgroup-bin
         $install cgroupfs-mount

--- a/util/install.sh
+++ b/util/install.sh
@@ -250,8 +250,9 @@ function of {
         $install git-core autotools-dev pkg-config libc6-dev
     fi
     # was: git clone git://openflowswitch.org/openflow.git
-    # Use our own fork on github for now:
-    git clone https://github.com/mininet/openflow
+    # also was: git clone https://github.com/mininet/openflow
+    # Now we use our own (Elroy) fork on github:
+    git clone https://github.com/elroyair/openflow.git
     cd $BUILD_DIR/openflow
 
     # Patch controller to handle more than 16 switches

--- a/util/install.sh
+++ b/util/install.sh
@@ -254,8 +254,6 @@ function of {
     # Now we use our own (Elroy) fork on github:
     git clone https://github.com/elroyair/openflow.git
     cd $BUILD_DIR/openflow
-    # @todo REMOVE THIS BEFORE MERGING TO MAIN
-    git checkout fix_strlcpy_bug
 
     # Patch controller to handle more than 16 switches
     patch -p1 < $MININET_DIR/mininet/util/openflow-patches/controller.patch

--- a/util/install.sh
+++ b/util/install.sh
@@ -254,6 +254,8 @@ function of {
     # Now we use our own (Elroy) fork on github:
     git clone https://github.com/elroyair/openflow.git
     cd $BUILD_DIR/openflow
+    # @todo REMOVE THIS BEFORE MERGING TO MAIN
+    git checkout fix_strlcpy_bug
 
     # Patch controller to handle more than 16 switches
     patch -p1 < $MININET_DIR/mininet/util/openflow-patches/controller.patch


### PR DESCRIPTION
Prerequisite: https://github.com/elroyair/openflow/pull/1

I don't feel too good about this. Feels hacky, but please note that the upstream repo's original script is pretty convoluted and not necessarily less hacky. The "right" way would be to more thoroughly refactor it, but I think it may only give us diminishing returns.

The most unpleasant thing here is the `pip install --break-system-packages` thing in the Makefile. Ideas welcome.

Also - using our fork of `openflow` now, but still applying mininet's hard-patching. Why did THEY fork openflow but not apply their own patch to it, but leave the patching to this repo? Should we just fold that in? Also, maybe just bring it in as a submodule instead of hard-cloning?

There is so much that I hate about this...